### PR TITLE
新特性：女巫总是掉落其正在饮用的药水

### DIFF
--- a/patches/net/minecraft/entity/monster/EntityWitch.java.patch
+++ b/patches/net/minecraft/entity/monster/EntityWitch.java.patch
@@ -1,0 +1,12 @@
+--- ../src-base/minecraft/net/minecraft/entity/monster/EntityWitch.java
++++ ../src-work/minecraft/net/minecraft/entity/monster/EntityWitch.java
+@@ -50,6 +50,9 @@
+     {
+         super(p_i1744_1_);
+         this.func_70105_a(0.6F, 1.95F);
++
++        // TC Plugin: change witch potion drop chance to 100%
++        this.field_82174_bp[EntityEquipmentSlot.MAINHAND.func_188454_b()] = 2.0F;
+     }
+ 
+     public static void func_189776_b(DataFixer p_189776_0_)


### PR DESCRIPTION
目前来说，由于女巫的药水效果的高风险性，当玩家遇到女巫时总是会选择回避而不是战斗。若让女巫可掉落其饮用的药水，那女巫则可在不失高风险的情况下拥有了击杀的价值。比如，你可以对女巫修脚而获得瞬间治疗1药水

当然，女巫掉药水的概率可以调整，并不一定是需要 100%，诸如 50% 等的数值也是可以的，可能需要进一步讨论