### PR TITLE
更容易的怪物消失

### DIFF
--- a/patches/net/minecraft/entity/EntityLiving.java.patch
+++ b/patches/net/minecraft/entity/EntityLiving.java.patch
@@ -1,0 +1,41 @@
+--- ../src-base/minecraft/net/minecraft/entity/EntityLiving.java
++++ ../src-work/minecraft/net/minecraft/entity/EntityLiving.java
+@@ -688,6 +688,12 @@
+         return true;
+     }
+ 
++    // TC Plugin adds interface for invoking
++    public void invokeDespawnEntity()
++    {
++        this.func_70623_bb();
++    }
++
+     protected void func_70623_bb()
+     {
+         if (this.field_82179_bU)
+@@ -710,7 +716,9 @@
+                     this.func_70106_y();
+                 }
+ 
+-                if (this.field_70708_bq > 600 && this.field_70146_Z.nextInt(800) == 0 && d3 > 1024.0D && this.func_70692_ba())
++                // TC Plugin: make randomly despawn easier
++//                if (this.idleTime > 600 && this.rand.nextInt(800) == 0 && d3 > 1024.0D && this.canDespawn())
++                if (this.field_70708_bq > 300 && this.field_70146_Z.nextInt(200) == 0 && d3 > 1024.0D && this.func_70692_ba())
+                 {
+                     this.func_70106_y();
+                 }
+@@ -725,9 +733,11 @@
+     protected final void func_70626_be()
+     {
+         ++this.field_70708_bq;
+-        this.field_70170_p.field_72984_F.func_76320_a("checkDespawn");
+-        this.func_70623_bb();
+-        this.field_70170_p.field_72984_F.func_76319_b();
++        // TC Plugin
++        // moves the despawn logic into net.minecraft.world.World#updateEntityWithOptionalForce
++//        this.world.profiler.startSection("checkDespawn");
++//        this.despawnEntity();
++//        this.world.profiler.endSection();
+         this.field_70170_p.field_72984_F.func_76320_a("sensing");
+         this.field_70723_bA.func_75523_a();
+         this.field_70170_p.field_72984_F.func_76319_b();

--- a/patches/net/minecraft/world/World.java.patch
+++ b/patches/net/minecraft/world/World.java.patch
@@ -1,0 +1,17 @@
+--- ../src-base/minecraft/net/minecraft/world/World.java
++++ ../src-work/minecraft/net/minecraft/world/World.java
+@@ -1409,6 +1409,14 @@
+                 entity2.func_184210_p();
+             }
+ 
++            // TC Plugin: immediately despawn check despite chunk loaded state check
++            if (entity2 instanceof EntityLiving)
++            {
++                this.field_72984_F.func_76320_a("checkDespawn");
++                ((EntityLiving)entity2).invokeDespawnEntity();
++                this.field_72984_F.func_76319_b();
++            }
++
+             this.field_72984_F.func_76320_a("tick");
+ 
+             if (!entity2.field_70128_L && !(entity2 instanceof EntityPlayerMP))


### PR DESCRIPTION
为了防止怪物扎堆在个别人附近的情况出现，这个 PR 做出了以下修改：

- 让生物在检查区块加载状态前就检查 despawn，也就是使用了 mc 1.15 的机制
- 增加了怪物在离玩家 32m ~ 128m 范围内随机消失的几率