### PR TITLE
Github Action 自动构建支持

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,38 @@
+name: Java CI with Gradle
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+
+    - name: Cache gradle files
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('*.gradle') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    - name: Clean up
+      run: rm -f gradle.properties
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Create Release
+      run: ./gradlew createRelease --stacktrace
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: TC UHC distribution for ${{ github.sha }}
+        path: ./build/distributions

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,4 +18,4 @@ gradle.ext.mappings = 'stable_39' // latest
 gradle.ext.useJavadocs = true
 
 // Whether to use the origial astyle formatting. false is recommended, set to true for compatibility with MCP.
-gradle.ext.useAstyle = true
+gradle.ext.useAstyle = false


### PR DESCRIPTION
白嫖的 CI 不用白不用，让宝宝能享受到最新的 GP 爱心特供款 TC UHC

效果见 [此处](https://github.com/Fallen-Breath/TC-UHC/actions)，在 push 或者 PR 时自动编译构建出发布包

关于 `gradle.ext.useAstyle` 这条设置，它会导致 CI 构建出错，关掉后也没看出有影响