### PR TITLE
新特性：为紫颂果传送添加世界边界检查

### DIFF
--- a/patches/net/minecraft/item/ItemChorusFruit.java.patch
+++ b/patches/net/minecraft/item/ItemChorusFruit.java.patch
@@ -1,0 +1,16 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemChorusFruit.java
++++ ../src-work/minecraft/net/minecraft/item/ItemChorusFruit.java
+@@ -35,6 +35,13 @@
+                     p_77654_3_.func_184210_p();
+                 }
+ 
++                // TC Plugin: world border check for chorus fruit
++                // If the destination is not inside the world border, skip this attempt
++                if (!p_77654_2_.func_175723_af().contains(d3, d5))
++                {
++                    continue;
++                }
++
+                 if (p_77654_3_.func_184595_k(d3, d4, d5))
+                 {
+                     p_77654_2_.func_184148_a((EntityPlayer)null, d0, d1, d2, SoundEvents.field_187544_ad, SoundCategory.PLAYERS, 1.0F, 1.0F);

--- a/patches/net/minecraft/world/border/WorldBorder.java.patch
+++ b/patches/net/minecraft/world/border/WorldBorder.java.patch
@@ -1,0 +1,15 @@
+--- ../src-base/minecraft/net/minecraft/world/border/WorldBorder.java
++++ ../src-work/minecraft/net/minecraft/world/border/WorldBorder.java
+@@ -47,6 +47,12 @@
+         return p_177743_1_.field_72336_d > this.func_177726_b() && p_177743_1_.field_72340_a < this.func_177728_d() && p_177743_1_.field_72334_f > this.func_177736_c() && p_177743_1_.field_72339_c < this.func_177733_e();
+     }
+ 
++    // TC Plugin: Added interface for chorus fruit teleportation check
++    public boolean contains(double x, double z)
++    {
++        return x > this.func_177726_b() && x < this.func_177728_d() && z > this.func_177736_c() && z < this.func_177733_e();
++    }
++
+     public double func_177745_a(Entity p_177745_1_)
+     {
+         return this.func_177729_b(p_177745_1_.field_70165_t, p_177745_1_.field_70161_v);


### PR DESCRIPTION
让紫颂果不会把人往边界外传送

具体实现：对于紫颂果的每一次传送尝试，在调用 `entityLiving.attemptTeleport` 方法前先使用 `worldIn.getWorldBorder().contains` 来判断目标位置是否位于世界边界之内，如果否，则 `continue` 跳过循环中的这次尝试

为了让世界边界支持检查浮点数坐标，我还在世界边界的类中添加了一个接受两个浮点数的 `contains` 方法

除了世界边界外，我认为还可以进一步完善的是，为紫颂果传送添加 Y 坐标的限制检查，避免玩家被传送至超出洞穴限制或空堡限制的范围