### PR TITLE
tab 玩家栏的信息显示

### DIFF
--- a/patches/net/minecraft/network/play/server/SPacketPlayerListHeaderFooter.java.patch
+++ b/patches/net/minecraft/network/play/server/SPacketPlayerListHeaderFooter.java.patch
@@ -1,0 +1,21 @@
+--- ../src-base/minecraft/net/minecraft/network/play/server/SPacketPlayerListHeaderFooter.java
++++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketPlayerListHeaderFooter.java
+@@ -11,6 +11,18 @@
+     private ITextComponent field_179703_a;
+     private ITextComponent field_179702_b;
+ 
++    // TC Plugin: setter
++    public void setHeader(ITextComponent header)
++    {
++        this.field_179703_a = header;
++    }
++
++    // TC Plugin: setter
++    public void setFooter(ITextComponent footer)
++    {
++        this.field_179702_b = footer;
++    }
++
+     public void func_148837_a(PacketBuffer p_148837_1_) throws IOException
+     {
+         this.field_179703_a = p_148837_1_.func_179258_d();

--- a/tcuhcSrc/cn/topologycraft/uhc/GameManager.java
+++ b/tcuhcSrc/cn/topologycraft/uhc/GameManager.java
@@ -129,6 +129,7 @@ public class GameManager extends Taskable {
 	
 	public void onServerInited() {
 		SpawnPlatform.generatePlatform(this, mcServer.worlds[0]);
+		this.addTask(new TaskHUDInfo(mcServer));
 	}
 	
 	public void postInit() {

--- a/tcuhcSrc/cn/topologycraft/uhc/task/TaskHUDInfo.java
+++ b/tcuhcSrc/cn/topologycraft/uhc/task/TaskHUDInfo.java
@@ -1,0 +1,39 @@
+package cn.topologycraft.uhc.task;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.play.server.SPacketPlayerListHeaderFooter;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
+
+public class TaskHUDInfo extends Task.TaskTimer
+{
+	private final MinecraftServer mcServer;
+
+	public TaskHUDInfo(MinecraftServer mcServer)
+	{
+		super(0, 5);
+		this.mcServer = mcServer;
+	}
+
+	private ITextComponent getHUDTexts(EntityPlayerMP player)
+	{
+		ITextComponent text = new TextComponentString("");
+		double mspt = MathHelper.average(this.mcServer.tickTimeArray) * 1.0E-6D;
+		double tps = 1000.0D / Math.max(mspt, 50.0D);
+		text.appendSibling(new TextComponentString(String.format("TPS: %.1f MSPT: %.1f Ping: %dms", tps, mspt, player.ping)));
+		return text;
+	}
+
+	@Override
+	public void onTimer()
+	{
+		this.mcServer.getPlayerList().getPlayers().forEach(player -> {
+			SPacketPlayerListHeaderFooter packet = new SPacketPlayerListHeaderFooter();
+			packet.setHeader(new TextComponentString(""));
+			packet.setFooter(this.getHUDTexts(player));
+			player.connection.sendPacket(packet);
+		});
+	}
+}


### PR DESCRIPTION
示例图：
![image](https://user-images.githubusercontent.com/28978806/111777940-e9245b00-88ee-11eb-8f30-13705dd07b27.png)

实现方式：在 `cn.topologycraft.uhc.GameManager#onServerInited` 中为 `GameManager` 添加了一个继承于 `Task.TaskTimer` 的自定义 `Task` ，间隔 5gt