### PR TITLE
Refactored PlayerItems and added more custom morals

### DIFF
--- a/patches/net/minecraft/item/ItemStack.java.patch
+++ b/patches/net/minecraft/item/ItemStack.java.patch
@@ -9,7 +9,15 @@
  import javax.annotation.Nullable;
  import net.minecraft.advancements.CriteriaTriggers;
  import net.minecraft.block.Block;
-@@ -345,6 +347,11 @@
+@@ -24,6 +26,7 @@
+ import net.minecraft.nbt.NBTBase;
+ import net.minecraft.nbt.NBTTagCompound;
+ import net.minecraft.nbt.NBTTagList;
++import net.minecraft.nbt.NBTTagString;
+ import net.minecraft.stats.StatList;
+ import net.minecraft.util.ActionResult;
+ import net.minecraft.util.EnumActionResult;
+@@ -345,6 +348,11 @@
          if (flag)
          {
              p_179548_4_.func_71029_a(StatList.func_188057_b(this.field_151002_e));
@@ -21,3 +29,18 @@
          }
      }
  
+@@ -716,6 +724,14 @@
+         this.field_77990_d.func_74768_a("RepairCost", p_82841_1_);
+     }
+ 
++    // TC Plugin: added method
++    public void setSingleLore(String lore)
++    {
++        NBTTagList loreList = new NBTTagList();
++        loreList.func_74742_a(new NBTTagString(lore));
++        this.func_190925_c("display").func_74782_a("Lore", loreList);
++    }
++
+     public Multimap<String, AttributeModifier> func_111283_C(EntityEquipmentSlot p_111283_1_)
+     {
+         Multimap<String, AttributeModifier> multimap;

--- a/tcuhcSrc/cn/topologycraft/uhc/GameCommand.java
+++ b/tcuhcSrc/cn/topologycraft/uhc/GameCommand.java
@@ -2,6 +2,7 @@ package cn.topologycraft.uhc;
 
 import cn.topologycraft.uhc.options.Options;
 import cn.topologycraft.uhc.task.TaskOnce;
+import cn.topologycraft.uhc.util.PlayerItems;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
@@ -143,6 +144,13 @@ public class GameCommand extends CommandBase {
 					} else {
 						sender.sendMessage(new TextComponentString(String.format("[%d, %d, %d]", pos.getX(), pos.getY(), pos.getZ())));
 					}
+					break;
+				}
+				case "givemorals": {
+					assertSenderPermission(sender);
+					EntityPlayerMP player = assertConsoleSender(sender);
+					PlayerItems.dumpMoralsToPlayer(player);
+					break;
 				}
 				default:
 					throw new CommandException(TextFormatting.RED + "Unknown command %s.", args[0]);

--- a/tcuhcSrc/cn/topologycraft/uhc/util/PlayerItems.java
+++ b/tcuhcSrc/cn/topologycraft/uhc/util/PlayerItems.java
@@ -1,45 +1,115 @@
 package cn.topologycraft.uhc.util;
 
 import com.google.common.collect.Maps;
+import net.minecraft.block.Block;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Enchantments;
 import net.minecraft.init.Items;
 import net.minecraft.init.PotionTypes;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.potion.PotionType;
 import net.minecraft.potion.PotionUtils;
 
 import java.util.Map;
+import java.util.function.Consumer;
 
 public class PlayerItems {
-	
-	private static Map<String, ItemStack> items = Maps.newHashMap();
-	
+
+	private static final Map<String, ItemStack> items = Maps.newLinkedHashMap();
+
 	public static ItemStack getPlayerItem(String playerName) {
 		ItemStack stack = items.get(playerName);
 		if (stack == null) stack = new ItemStack(Items.PAPER);
 		else stack = stack.copy();
-		if (!stack.hasDisplayName())
-			stack.setStackDisplayName(playerName + "'s moral(jie) integrity(cao)");
+		String moral = playerName + "'s moral(jie) integrity(cao)";
+		if (!stack.hasDisplayName()) stack.setStackDisplayName(moral);
+		else stack.setSingleLore(moral);
 		if (stack.getEnchantmentTagList().tagCount() == 0)
 			stack.addEnchantment(Enchantments.SHARPNESS, 1);
 		return stack;
 	}
+
+	// for command /uhc givemorals
+	public static void dumpMoralsToPlayer(EntityPlayer player) {
+		items.keySet().forEach(name -> player.inventory.addItemStackToInventory(getPlayerItem(name)));
+	}
 	
 	static {
-		ItemStack stack = null;
-		stack = new ItemStack(Items.POTIONITEM);
-		PotionUtils.addPotionToItemStack(stack, PotionTypes.STRONG_POISON);
-		items.put("hungryartist_", stack.setStackDisplayName("hungryartist_'s holy water"));
+		items.put("hungryartist_", Builder.create(Items.POTIONITEM).potion(PotionTypes.STRONG_POISON).named("hungryartist_'s holy water").get());
 		items.put("_Flag_E_", new ItemStack(Blocks.RED_FLOWER));
 		items.put("Spring0809", new ItemStack(Blocks.TNT));
 		items.put("fire_duang_duang", new ItemStack(Items.COOKED_FISH).setStackDisplayName("fire_duang_duang's salted fish"));
-		stack = new ItemStack(Items.WOODEN_SWORD, 1, 59);
-		stack.addEnchantment(Enchantments.SHARPNESS, 10);
-		stack.getTagCompound().setInteger("RepairCost", 100);
-		items.put("Keviince", stack);
+		items.put("Keviince", Builder.create(Items.WOODEN_SWORD, 59).enchant(Enchantments.SHARPNESS, 10).expensive().get());
 		items.put("Dazo66", new ItemStack(Blocks.YELLOW_FLOWER));
 		items.put("Gamepiaynmo", new ItemStack(Items.COAL));
 		items.put("CCS_Covenant", new ItemStack(Items.COOKIE).setStackDisplayName("Crispy Crispy Shark!"));
+		items.put("Lancet_Corgi", Builder.create(Items.IRON_SWORD, 250).enchant(Enchantments.SHARPNESS, 5).expensive().get());
+		items.put("ajisai_iii", new ItemStack(Items.CHICKEN));
+		items.put("Aschin", Builder.create(Items.WHEAT).named("comymy").get());
+		items.put("Dou_Bi_Long", Builder.create(Blocks.DRAGON_EGG).named("longbao no egg").enchant(Enchantments.UNBREAKING, 10).enchant(Enchantments.MENDING, 1).get());
+		items.put("minamotosan", Builder.create(Items.ROTTEN_FLESH).named("spicy strip").get());
+		items.put("zi_nv", Builder.create(Blocks.DOUBLE_PLANT, 2).named("mY lIVe").enchant(Enchantments.EFFICIENCY, 11).get());
+		items.put("CallMeLecten", Builder.create(Items.GLASS_BOTTLE).named("oxygen").get());
+		items.put("HG_Fei", Builder.create(Items.POTIONITEM).named("hydrofluoric acid").get());
+		items.put("hai_dan", Builder.create(Items.EGG).named("sea egg").get());
+		items.put("Fallen_Breath", Builder.create(Items.LEATHER_CHESTPLATE).mani(s -> Items.LEATHER_CHESTPLATE.setColor(s, 16742436)).named("fox fur coat").get());
+		items.put("Sanluli36li", Builder.create(Items.TNT_MINECART).named("36li's self-destruct-car").enchant(Enchantments.FORTUNE, 3).get());
+		items.put("shamreltuim", Builder.create(Items.FISH, 3).get());  // puffer fish
+		items.put("YtonE", Builder.create(Items.POTIONITEM).potion(PotionTypes.EMPTY).get());  // uncraftable potion
 	}
 
+	private static class Builder
+	{
+		private final ItemStack itemStack;
+
+		private Builder(ItemStack itemStack) {
+			this.itemStack = itemStack;
+		}
+
+		private static Builder create(Item item, int meta) {
+			return new Builder(new ItemStack(item, 1, meta));
+		}
+
+		private static Builder create(Item item) {
+			return new Builder(new ItemStack(item));
+		}
+
+		public static Builder create(Block block, int meta)
+		{
+			return create(Item.getItemFromBlock(block), meta);
+		}
+
+		public static Builder create(Block block)
+		{
+			return create(Item.getItemFromBlock(block));
+		}
+
+		private Builder mani(Consumer<ItemStack> consumer) {
+			consumer.accept(this.itemStack);
+			return this;
+		}
+
+		private Builder named(String name) {
+			return this.mani(s -> s.setStackDisplayName(name));
+		}
+
+		private Builder potion(PotionType potionType) {
+			return this.mani(s -> PotionUtils.addPotionToItemStack(s, potionType));
+		}
+
+		private Builder enchant(Enchantment ench, int level) {
+			return this.mani(s -> s.addEnchantment(ench, level));
+		}
+
+		private Builder expensive() {
+			return this.mani(stack -> stack.setRepairCost(100));
+		}
+
+		private ItemStack get() {
+			return this.itemStack;
+		}
+	}
 }


### PR DESCRIPTION
- Used builder to create player items
- Added a few custom morals
- Added method `setSingleLore` in ItemStack
- Added `/uhc givemorals` to get all morals, for debugging or preview
- Fixed `/uhc deathpos` showing "Unknown command" by adding a `break;`
- Added text `someone's moral(jie) integrity(cao)` to the lore of the item if the item has custom name, so you can always tell who this moral belongs to

![image](https://user-images.githubusercontent.com/28978806/118294497-59c1af80-b50d-11eb-9d39-5ca9694953b7.png)
