### PR TITLE
Fixed enchant golden apple issue

### DIFF
--- a/patches/net/minecraft/potion/PotionEffect.java.patch
+++ b/patches/net/minecraft/potion/PotionEffect.java.patch
@@ -1,0 +1,21 @@
+--- ../src-base/minecraft/net/minecraft/potion/PotionEffect.java
++++ ../src-work/minecraft/net/minecraft/potion/PotionEffect.java
+@@ -2,6 +2,7 @@
+ 
+ import com.google.common.collect.ComparisonChain;
+ import net.minecraft.entity.EntityLivingBase;
++import net.minecraft.init.MobEffects;
+ import net.minecraft.nbt.NBTTagCompound;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+@@ -56,7 +57,9 @@
+             field_180155_a.warn("This method should only be called for matching effects!");
+         }
+ 
+-        if (p_76452_1_.field_76461_c > this.field_76461_c)
++        // TC Plugin: Backport 1.13.2 potion effect logic, in order to fix the bug that
++        // eating gapple after eating e-gapple can reset the ABSORPTION to e-gapple level
++        if (p_76452_1_.field_76461_c > this.field_76461_c || this.field_188420_b == MobEffects.field_76444_x)
+         {
+             this.field_76461_c = p_76452_1_.field_76461_c;
+             this.field_76460_b = p_76452_1_.field_76460_b;


### PR DESCRIPTION
## What

It's a vanilla issue which affects all status effects

To reproduce the issue:

1. Eat an enchanted golden apple, then you will have 8 golden hearts
2. Consume all your golden hearts
3. Eat a regular golden apple

Expect: you get another 2 golden hearts, given by the regular golden apple

Actually: you get another 8 golden hearts

## Fix

I just do a little change to the code in `PotionEffect` class: Special judging ABSORPTION effect. If it's ABSORPTION then just overwrite the existed potion
