### PR TITLE
新增两个游戏模式：Ghost、King

### DIFF
--- a/patches/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -9,7 +9,19 @@
  import java.nio.charset.StandardCharsets;
  import java.util.List;
  import java.util.UUID;
-@@ -1791,6 +1793,9 @@
+@@ -613,7 +615,10 @@
+ 
+             if (!itemstack.func_190926_b() && EnchantmentHelper.func_190939_c(itemstack))
+             {
+-                this.field_71071_by.func_70304_b(i);
++                // TC Plugin: Added tag check for KING mode's king's crown item
++                if (!(itemstack.func_77978_p() != null && itemstack.func_77978_p().func_74764_b("KingsCrown"))) {
++                    this.field_71071_by.func_70304_b(i);
++                }
+             }
+         }
+     }
+@@ -1791,6 +1796,9 @@
          {
              this.func_71029_a(entitylist$entityegginfo.field_151512_d);
          }

--- a/patches/net/minecraft/item/EnumDyeColor.java.patch
+++ b/patches/net/minecraft/item/EnumDyeColor.java.patch
@@ -1,0 +1,15 @@
+--- ../src-base/minecraft/net/minecraft/item/EnumDyeColor.java
++++ ../src-work/minecraft/net/minecraft/item/EnumDyeColor.java
+@@ -66,6 +66,12 @@
+         return this.field_193352_x;
+     }
+ 
++    // TC Plugin: added getter
++    public int func_193350_e()
++    {
++        return field_193351_w;
++    }
++
+     public static EnumDyeColor func_176766_a(int p_176766_0_)
+     {
+         if (p_176766_0_ < 0 || p_176766_0_ >= field_176789_r.length)

--- a/tcuhcSrc/cn/topologycraft/uhc/GameManager.java
+++ b/tcuhcSrc/cn/topologycraft/uhc/GameManager.java
@@ -74,6 +74,7 @@ public class GameManager extends Taskable {
 	public boolean isGamePlaying() { return isGamePlaying; }
 	public boolean isConfiguring() { return configManager.isConfiguring(); }
 	public boolean hasGameEnded() { return isGameEnded; }
+	public static EnumMode getGameMode() { return (EnumMode)instance.getOptions().getOptionValue("gameMode"); }
 	
 	public void onPlayerJoin(EntityPlayerMP player) {
 		try {
@@ -192,10 +193,12 @@ public class GameManager extends Taskable {
 		}
 		boolean autoTeams = uhcOptions.getBooleanOptionValue("randomTeams");
 		if (!playerManager.formTeams(autoTeams)) return;
-		if ((EnumMode) uhcOptions.getOptionValue("gameMode") == EnumMode.BOSS) {
-			bossInfo = Optional.of(new BossInfoServer(new TextComponentString(playerManager.getBossPlayer().getName()), BossInfo.Color.PURPLE, BossInfo.Overlay.PROGRESS));
-			playerList.getPlayers().forEach(player -> bossInfo.ifPresent(info -> info.addPlayer(player)));
-			bossInfo.ifPresent(info -> info.setVisible(true));
+		switch (getGameMode()) {
+			case BOSS:
+				bossInfo = Optional.of(new BossInfoServer(new TextComponentString(playerManager.getBossPlayer().getName()), BossInfo.Color.PURPLE, BossInfo.Overlay.PROGRESS));
+				playerList.getPlayers().forEach(player -> bossInfo.ifPresent(info -> info.addPlayer(player)));
+				bossInfo.ifPresent(info -> info.setVisible(true));
+				break;
 		}
 		isGamePlaying = true;
 		this.initWorlds();
@@ -349,9 +352,23 @@ public class GameManager extends Taskable {
 	}
 	
 	public static enum EnumMode {
-		NORMAL,
-		SOLO,
-		BOSS;
+		NORMAL(true),
+		SOLO(false),
+		BOSS(false),
+		GHOST(false),
+		KING(true);
+
+		private final boolean deathRegen;
+
+		EnumMode(boolean deathRegen)
+		{
+			this.deathRegen = deathRegen;
+		}
+
+		public boolean doDeathRegen()
+		{
+			return deathRegen;
+		}
 	}
 
 }

--- a/tcuhcSrc/cn/topologycraft/uhc/GamePlayer.java
+++ b/tcuhcSrc/cn/topologycraft/uhc/GamePlayer.java
@@ -5,6 +5,8 @@ import cn.topologycraft.uhc.task.Taskable;
 import com.google.common.collect.Maps;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.init.MobEffects;
+import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.math.BlockPos;
 
 import java.lang.ref.WeakReference;
@@ -50,6 +52,10 @@ public class GamePlayer extends Taskable {
 	public boolean isSamePlayer(EntityPlayer player) {
 		return player != null && playerUUID.equals(player.getUniqueID());
 	}
+
+	public boolean isKing() {
+		return this.getTeam() != null && this.getTeam().getKing() == this;
+	}
 	
 	public void setDead(int curTime) {
 		if (isAlive) {
@@ -75,7 +81,12 @@ public class GamePlayer extends Taskable {
 	public Optional<EntityPlayerMP> getRealPlayer() {
 		return playerManager.getPlayerByUUID(playerUUID);
 	}
-	
+
+	public void addGhostModeEffect()
+	{
+		this.getRealPlayer().ifPresent(player -> player.addPotionEffect(new PotionEffect(MobEffects.INVISIBILITY, Integer.MAX_VALUE, 0, true, false)));
+	}
+
 	public static enum EnumStat {
 		PLAYER_KILLED("Player Killed"),
 		ENTITY_KILLED("Entity Killed"),

--- a/tcuhcSrc/cn/topologycraft/uhc/GameTeam.java
+++ b/tcuhcSrc/cn/topologycraft/uhc/GameTeam.java
@@ -20,7 +20,10 @@ public class GameTeam {
 	public GameTeam addPlayer(GamePlayer player) { players.add(player); player.setTeam(this); return this; }
 	public GameTeam removePlayer(GamePlayer player) { players.remove(player); return this; }
 	public Iterable<GamePlayer> getPlayers() { return players; }
-	
+
+	// The first player of the team is always the king
+	public GamePlayer getKing() { return GameManager.getGameMode() == GameManager.EnumMode.KING ? players.get(0) : null; }
+
 	public void clearTeam() {
 		players.clear();
 	}

--- a/tcuhcSrc/cn/topologycraft/uhc/task/TaskFindPlayer.java
+++ b/tcuhcSrc/cn/topologycraft/uhc/task/TaskFindPlayer.java
@@ -11,7 +11,11 @@ public class TaskFindPlayer extends Task {
 	public TaskFindPlayer(GamePlayer player) {
 		this.player = player;
 	}
-	
+
+	public GamePlayer getGamePlayer() {
+		return player;
+	}
+
 	public void onFindPlayer(EntityPlayerMP player) { }
 	
 	@Override

--- a/tcuhcSrc/cn/topologycraft/uhc/task/TaskKingEffectField.java
+++ b/tcuhcSrc/cn/topologycraft/uhc/task/TaskKingEffectField.java
@@ -9,21 +9,22 @@ public class TaskKingEffectField extends Task.TaskTimer
 {
 	public TaskKingEffectField()
 	{
-		super(0, 20);
+		super(0, 10);
 	}
 
-	// give 2 seconds resistance I to any player near its king
+	// give 2 seconds speed I to any player near its king
 	@Override
 	public void onTimer()
 	{
 		if (GameManager.instance.isGamePlaying() && GameManager.getGameMode() == GameManager.EnumMode.KING) {
 			GameManager.instance.getPlayerManager().getCombatPlayers().forEach(gamePlayer -> {
+				// only non-king players are able to have the boost
 				if (!gamePlayer.isKing() && gamePlayer.isAlive() && gamePlayer.getRealPlayer().isPresent()) {
 					GamePlayer king = gamePlayer.getTeam().getKing();
 					if (king.isAlive() && king.getRealPlayer().isPresent()) {
 						double distanceToKing = gamePlayer.getRealPlayer().get().getDistance(king.getRealPlayer().get());
-						if (distanceToKing <= 8) {
-							gamePlayer.getRealPlayer().get().addPotionEffect(new PotionEffect(MobEffects.RESISTANCE, 0, 40));
+						if (distanceToKing <= 5) {
+							gamePlayer.getRealPlayer().get().addPotionEffect(new PotionEffect(MobEffects.SPEED, 0, 40));
 						}
 					}
 				}

--- a/tcuhcSrc/cn/topologycraft/uhc/task/TaskKingEffectField.java
+++ b/tcuhcSrc/cn/topologycraft/uhc/task/TaskKingEffectField.java
@@ -24,7 +24,7 @@ public class TaskKingEffectField extends Task.TaskTimer
 					if (king.isAlive() && king.getRealPlayer().isPresent()) {
 						double distanceToKing = gamePlayer.getRealPlayer().get().getDistance(king.getRealPlayer().get());
 						if (distanceToKing <= 5) {
-							gamePlayer.getRealPlayer().get().addPotionEffect(new PotionEffect(MobEffects.SPEED, 0, 40));
+							gamePlayer.getRealPlayer().get().addPotionEffect(new PotionEffect(MobEffects.SPEED, 40, 0));
 						}
 					}
 				}

--- a/tcuhcSrc/cn/topologycraft/uhc/task/TaskKingEffectField.java
+++ b/tcuhcSrc/cn/topologycraft/uhc/task/TaskKingEffectField.java
@@ -1,0 +1,36 @@
+package cn.topologycraft.uhc.task;
+
+import cn.topologycraft.uhc.GameManager;
+import cn.topologycraft.uhc.GamePlayer;
+import net.minecraft.init.MobEffects;
+import net.minecraft.potion.PotionEffect;
+
+public class TaskKingEffectField extends Task.TaskTimer
+{
+	public TaskKingEffectField()
+	{
+		super(0, 20);
+	}
+
+	// give 2 seconds resistance I to any player near its king
+	@Override
+	public void onTimer()
+	{
+		if (GameManager.instance.isGamePlaying() && GameManager.getGameMode() == GameManager.EnumMode.KING) {
+			GameManager.instance.getPlayerManager().getCombatPlayers().forEach(gamePlayer -> {
+				if (!gamePlayer.isKing() && gamePlayer.isAlive() && gamePlayer.getRealPlayer().isPresent()) {
+					GamePlayer king = gamePlayer.getTeam().getKing();
+					if (king.isAlive() && king.getRealPlayer().isPresent()) {
+						double distanceToKing = gamePlayer.getRealPlayer().get().getDistance(king.getRealPlayer().get());
+						if (distanceToKing <= 8) {
+							gamePlayer.getRealPlayer().get().addPotionEffect(new PotionEffect(MobEffects.RESISTANCE, 0, 40));
+						}
+					}
+				}
+			});
+		}
+		else {
+			this.setCanceled();
+		}
+	}
+}

--- a/tcuhcSrc/cn/topologycraft/uhc/task/TaskTitleCountDown.java
+++ b/tcuhcSrc/cn/topologycraft/uhc/task/TaskTitleCountDown.java
@@ -4,10 +4,19 @@ import cn.topologycraft.uhc.GameManager;
 import cn.topologycraft.uhc.task.Task.TaskTimer;
 import cn.topologycraft.uhc.util.TitleUtil;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.init.Enchantments;
+import net.minecraft.init.Items;
 import net.minecraft.init.MobEffects;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.EnumDyeColor;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagByte;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.potion.PotionUtils;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.GameType;
+
+import java.util.Collections;
 
 public class TaskTitleCountDown extends TaskTimer {
 	
@@ -32,10 +41,37 @@ public class TaskTitleCountDown extends TaskTimer {
 			public void onFindPlayer(EntityPlayerMP player) {
 				player.setGameType(GameType.SURVIVAL);
 				player.setEntityInvulnerable(false);
+				player.clearActivePotions();
 				GameManager.instance.getPlayerManager().resetHealthAndFood(player);
 				player.addPotionEffect(new PotionEffect(MobEffects.RESISTANCE, 200, 4));  // 10s Resistance V
+
+				// give invisibility and shiny potion to player for ghost mode
+				switch (GameManager.getGameMode()) {
+					case GHOST:
+						this.getGamePlayer().addGhostModeEffect();
+						ItemStack shinyPotion = new ItemStack(Items.SPLASH_POTION).setStackDisplayName("Splash Shiny Potion");
+						PotionUtils.appendEffects(shinyPotion, Collections.singleton(new PotionEffect(MobEffects.GLOWING, 200, 0)));
+						player.inventory.addItemStackToInventory(shinyPotion);
+						break;
+					case KING:
+						if (this.getGamePlayer().isKing()) {
+							EnumDyeColor dyeColor = this.getGamePlayer().getTeam().getTeamColor().dyeColor;
+							ItemStack kingsHelmet = new ItemStack(Items.LEATHER_HELMET).setStackDisplayName(String.format("%s crown", dyeColor.getName()));
+							kingsHelmet.setTagInfo("KingsCrown", new NBTTagByte((byte)1));
+							kingsHelmet.setTagInfo("Unbreakable", new NBTTagByte((byte)1));
+							Items.LEATHER_HELMET.setColor(kingsHelmet, dyeColor.getColorValue());
+							kingsHelmet.addEnchantment(Enchantments.PROTECTION, 6);
+							kingsHelmet.addEnchantment(Enchantments.BINDING_CURSE, 1);
+							kingsHelmet.addEnchantment(Enchantments.VANISHING_CURSE, 1);
+							player.setItemStackToSlot(EntityEquipmentSlot.HEAD, kingsHelmet);
+						}
+						break;
+				}
 			}
 		}));
+		if (GameManager.getGameMode() == GameManager.EnumMode.KING) {
+			GameManager.instance.addTask(new TaskKingEffectField());
+		}
 		GameManager.instance.addTask(new TaskScoreboard());
 	}
 

--- a/tcuhcSrc/cn/topologycraft/uhc/util/BookNBT.java
+++ b/tcuhcSrc/cn/topologycraft/uhc/util/BookNBT.java
@@ -122,6 +122,7 @@ public class BookNBT {
 					break;
 				}
 				case SOLO: 
+				case GHOST:
 					text.appendSibling(createTextEvent(line, "/uhc select 9", "Select to fight", TextFormatting.BLACK));
 					break;
 				case BOSS: {
@@ -150,7 +151,8 @@ public class BookNBT {
 		
 		switch ((GameManager.EnumMode) options.getOptionValue("gameMode")) {
 			case BOSS:
-			case NORMAL: {
+			case NORMAL:
+			case KING: {
 				for (GameTeam team : gameManager.getPlayerManager().getTeams()) {
 					ITextComponent text = new TextComponentString(team.getColorfulTeamName() + "\n\n");
 					for (GamePlayer player : team.getPlayers()) {
@@ -160,7 +162,8 @@ public class BookNBT {
 				}
 				break;
 			}
-			case SOLO: {
+			case SOLO:
+			case GHOST: {
 				ITextComponent text = new TextComponentString(TextFormatting.LIGHT_PURPLE + "All Players\n\n");
 				for (GamePlayer player : gameManager.getPlayerManager().getCombatPlayers()) {
 					text.appendSibling(createPlayerText(player));


### PR DESCRIPTION
## Ghost Mode 隐身模式

基于 SOLO 模式

所有人拥有无限时长的无粒子效果的隐身药水效果

游戏开始时所有玩家将会获得一瓶 10s 的喷溅发光药水

建议与较小的地图边界与较短的游戏时间配合使用

## King Mode 国王模式

灵感来自：SST 的国王游戏

基于 NORMAL 模式

队伍中的第一个玩家将会成为国王，国王将自动戴上与其队伍颜色相对应颜色的皮革帽子，带有保护 6、绑定诅咒、消失诅咒的附魔，无法破坏

在己方国王附近的队友可获得短暂的速度 1 效果。实现见 `TaskKingEffectField`

当国王死亡时，该国王的所有成员也一并死亡

## TODO

需要进一步的内测以完善相关的细节
